### PR TITLE
Matt/url from env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ npm start
 
 This will start the development server.
 
+## Running with local API server
+
+Set the `REACT_APP_API_SERVER` variable in your environment and it will be used
+as the API server instead of the production server in development or testing
+environments.
+
+For example:
+
+```bash
+REACT_APP_API_SERVER=https://localhost:9999 npm start
+```
+
 ## Scripts
 
 In the project directory, you can run:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,13 @@ type ServerResponse = {
   route: LatLngExpression[];
 } & Response;
 
-const API_URL = "https://car-dependence-backend.herokuapp.com/api/route/";
+// In production, talk to production. In development, prefer REACT_APP_API_URL variable
+// (e.g. from command `REACT_APP_API_URL=localhost:8000 npm start`)
+// Otherwise fall back to production server
+const API_URL =
+  process.env.NODE_ENV === "production" || !process.env.REACT_APP_API_URL
+    ? "https://car-dependence-backend.herokuapp.com/api/route/"
+    : process.env.REACT_APP_API_URL;
 
 const MAP_FILL_SCREEN_STYLE = { width: "100vw", height: "100vh" };
 


### PR DESCRIPTION
This lets you specify the API endpoint as an environment variable `REACT_APP_API_SERVER`. eg:

```bash
REACT_APP_API_SERVER=https://localhost:9999 npm start
```

(also added to README)