### PR TITLE
Valid latlon only

### DIFF
--- a/src/hooks/useMapBBox.ts
+++ b/src/hooks/useMapBBox.ts
@@ -9,12 +9,7 @@ function useBBox(map: Map) {
 
   const onMove = useCallback(() => {
     const center = map.getCenter();
-    if (
-      center.lat >= -90 &&
-      center.lat <= 90 &&
-      center.lng >= -180 &&
-      center.lng <= 180
-    ) {
+    if (center.lng >= -180 && center.lng <= 180) {
       setBBox(map.getBounds());
     } else {
       const validLat = center.lat;
@@ -22,10 +17,6 @@ function useBBox(map: Map) {
       const newCenter = new LatLng(validLat, validLon);
       map.setView(newCenter, undefined, { animate: false });
     }
-  }, [map]);
-
-  const onZoom = useCallback(() => {
-    setBBox(map.getBounds());
   }, [map]);
 
   // adds the required event listeners for Leaflet to handle this properly
@@ -36,7 +27,7 @@ function useBBox(map: Map) {
       map.off("moveend", onMove);
       map.off("zoomend", onMove);
     };
-  }, [map, onMove, onZoom]);
+  }, [map, onMove]);
 
   return bbox;
 }

--- a/src/hooks/useMapBBox.ts
+++ b/src/hooks/useMapBBox.ts
@@ -9,12 +9,13 @@ function useBBox(map: Map) {
 
   const onMove = useCallback(() => {
     const center = map.getCenter();
+    // longitude can cause problem, since leaflet scrolls forever left/right and longitude grows/shrinks accordingly
     if (center.lng >= -180 && center.lng <= 180) {
       setBBox(map.getBounds());
+      // if its out of range, snap back to real-world coordinate
     } else {
-      const validLat = center.lat;
       const validLon = asValidLon(center.lng);
-      const newCenter = new LatLng(validLat, validLon);
+      const newCenter = new LatLng(center.lat, validLon);
       map.setView(newCenter, undefined, { animate: false });
     }
   }, [map]);


### PR DESCRIPTION
This fixes a bug where since Leaflet scrolls infinitely east/west, longitude can become invalid. It checks the center at every map movement, and if longitude is invalid, corrects it.